### PR TITLE
10 imprv buildtools

### DIFF
--- a/build/compile.js
+++ b/build/compile.js
@@ -1,0 +1,82 @@
+var rjs = require('requirejs');
+var path = require('path');
+var fs = require('fs');
+var exec = require('child_process').exec;
+
+module.exports = function(grunt) {
+  var buildDirCMD = [
+      'rm -Rf {buildDir}',
+      'mkdir {buildDir}',
+      'find . -depth 1 | {exclusionGrep} | while read x; do cp -R $x ./build/${x}; done'
+  ].join(' && ');
+  var compileToplevelCMD = 'jam compile -o ./build/jam/require.js --no-minify';
+  var compileAppCMD = 'jam compile -i {appPath} -e requireLib {otherExclusions} -o ./build/{appPath}.js --no-minify';
+
+  grunt.task.registerTask('compile', 'Builds an application radagast suite with jam and requirejs.', function () {
+    var options = grunt.config(this.name) || {};
+
+    // sane defaults...
+    options.buildDir     = options.buildDir || './build';
+    options.buildExclude = (options.buildExclude) ? [].concat(options.buildExclude) : [];
+    options.buildExclude.push('./build'); // just in case (doesnt hurt to have duplicates)
+
+    // prepare data
+    var buildExcludeGrep = options.buildExclude.map(function(e) { return 'grep -v "' + e + '"'; }).join('|');
+    buildDirCMD = buildDirCMD
+      .replace(/\{buildDir\}/g, options.buildDir)
+      .replace(/\{exclusionGrep\}/g, buildExcludeGrep);
+    var appPaths = collectAppPaths(options.apps);
+    compileAppCMD = appPaths.map(function(p) { return compileAppCMD.replace(/\{appPath\}/g, p); }).join(' && ');
+    
+    // execute
+    var done = this.async();
+    grunt.log.writeln('Creating build directory');
+    grunt.log.writeln('\033[0;30m'+buildDirCMD+'\033[1;37m');
+    exec(buildDirCMD, function(err, stdout, stderr) {
+      if (err) throw stderr;
+
+      grunt.log.writeln('Compiling top-level');
+      grunt.log.writeln('\033[0;30m'+compileToplevelCMD+'\033[1;37m');
+      exec(compileToplevelCMD, function(err, stdout, stderr) {
+        if (err) throw stderr;
+        grunt.log.writeln(stdout);
+
+        compileAppCMD = excludeWhatToplevelIncluded(stdout, compileAppCMD);
+        grunt.log.writeln('Compiling applications');
+        grunt.log.writeln('\033[0;30m'+compileAppCMD+'\033[1;37m');
+        exec(compileAppCMD, function(err, stdout, stderr) {
+          if (err) { console.log(stdout, stderr, err); throw stderr; }
+          grunt.log.writeln(stdout);
+          done();
+        });
+      });
+    });
+  });
+
+  function collectAppPaths(apps) {
+    var appPaths = [];
+    if (apps) {
+      apps.forEach(function(app) {
+        // the packages use a define call to export their config
+        // this define function grabs that config and adds it to our modules
+        var define = function(pkgFn) {
+          appPaths.push(path.join(app, pkgFn().path));
+        };
+
+        // load the package js and eval it in this scope
+        var pkgRawJS = fs.readFileSync(path.join(process.cwd(), app, 'package.js'), 'utf8');
+        eval(pkgRawJS);
+      });
+    }
+    return appPaths;
+  }
+
+  function excludeWhatToplevelIncluded(stdout, cmd) {
+    // parse out what the toplevel included
+    var includes = /include \u001b\[39m(.*)/.exec(stdout);
+    //console.log('includes', includes[1]);
+    var excludes = includes[1].split(', ').map(function(item) { return '-E '+item; }).join(' ');
+    //console.log('excludes', excludes);
+    return cmd.replace(/\{otherExclusions\}/g, excludes);
+  }
+};

--- a/examples/goodybag-site/grunt.js
+++ b/examples/goodybag-site/grunt.js
@@ -1,0 +1,30 @@
+/*global module:false*/
+module.exports = function(grunt) {
+
+  // Project configuration.
+  grunt.initConfig({
+    pkg: '<json:package.json>',
+    meta: {
+      banner: '/*! <%= pkg.title || pkg.name %> - v<%= pkg.version %> - ' +
+        '<%= grunt.template.today("yyyy-mm-dd") %>\n' +
+        '<%= pkg.homepage ? "* " + pkg.homepage + "\n" : "" %>' +
+        '* Copyright (c) <%= grunt.template.today("yyyy") %> <%= pkg.author.name %>;' +
+        ' Licensed <%= _.pluck(pkg.licenses, "type").join(", ") %> */'
+    },
+    compile: {
+      buildDir: './build',
+      buildExclude: ['./build'],
+      apps: [
+        "apps/application-suite",
+        "apps/landing-site",
+        "apps/consumer-panel"
+      ]
+    }
+  });
+
+  // Default task.
+  grunt.registerTask('default', 'compile');
+
+  // Load rad tasks
+  grunt.loadTasks('../../build');
+};

--- a/src/apps-handler.js
+++ b/src/apps-handler.js
@@ -73,14 +73,17 @@ define(function(require){
           if (!this.isLoaded(name)){
             var this_ = this, app = this.apps[name];
 
-            return require([app.path, app.routerPath], function(module, routeHandlers){
-              // save some references for instance object
-              module.prototype._package = app;
-              module.prototype._routeHandlers = routeHandlers;
+            return require([app.path], function(module){
+              // include app.path first, as the router will be defined in that file if compiled
+              require([app.routerPath], function(routeHandlers){
+                // save some references for instance object
+                module.prototype._package = app;
+                module.prototype._routeHandlers = routeHandlers;
 
-              // Tell handler we've loaded this module
-              this_.loaded[name] = module;
-              callback(null, module);
+                // Tell handler we've loaded this module
+                this_.loaded[name] = module;
+                callback(null, module);
+              });
             }), this;
           }
           return callback(null, this.loaded[name]), this;

--- a/src/radagast.js
+++ b/src/radagast.js
@@ -1,15 +1,15 @@
 define(function(require){
-  var pubsub = require('./src/pubsub');
+  var pubsub = require('radagast/src/pubsub');
 
   var Radagast = {
     // imported APIs
-    utils       : require('./src/utils')
-  , apps        : require('./src/apps-handler')
-  , App         : require('./src/app')
-  , Suite       : require('./src/suite')
-  , logger      : require('./src/logger')
-  , config      : require('./src/config')
-  , css         : require('./src/css')
+    utils       : require('radagast/src/utils')
+  , apps        : require('radagast/src/apps-handler')
+  , App         : require('radagast/src/app')
+  , Suite       : require('radagast/src/suite')
+  , logger      : require('radagast/src/logger')
+  , config      : require('radagast/src/config')
+  , css         : require('radagast/src/css')
   , publish     : pubsub.publish
   , subscribe   : pubsub.subscribe
   , unsubscribe : pubsub.unsubscribe

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,8 +3,11 @@ define(function(require){
     // 3rd Party Dependencies
     $         = require('jquery')
   , _         = require('lodash')
-  , Backbone  = require('backbone')
   , domready  = require('domReady')
+    // tell requirejs that backbone is a dep, but use the global one
+    // (backbone's shim, when compiled, provides a bad value to require
+    //  so we're better off using the global)
+  , bb        = require('backbone')
 
     // Module Variables
   , utils     = {}


### PR DESCRIPTION
added grunt task which uses jam's CLI 'compile' command

Usage:

Create a `grunt.js` file in the application's base directory, as is the case in the goodybag-site example. Run `grunt compile` to produce the ./build directory (`grunt compile:no-minify` to only concat). The build directory will copy the entire project, but replace `jam/require.js` and application main scripts with the built output.

Notes:
- relies on a small update to jam's compile task which is awaiting pull from the maintainers
- currently, package.js is not included in the optimization (it was very buggy, and I felt like it was better to let the project stabilize before investing the time in a fix)
